### PR TITLE
Linting fixes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,4 +31,6 @@ jobs:
       - name: Test
         run: make test
       - name: Lint
-        run: make lint
+        uses: golangci/golangci-lint-action@v4
+        with:
+          version: v1.57.2

--- a/main.go
+++ b/main.go
@@ -110,7 +110,7 @@ func newGithubClient(ctx context.Context) (*github.Client, error) {
 		if !apiUrlPresent {
 			apiUrl = serverUrl
 		}
-		return github.NewEnterpriseClient(apiUrl, serverUrl, tc)
+		return github.NewClient(tc).WithEnterpriseURLs(apiUrl, serverUrl)
 	}
 	return github.NewClient(tc), nil
 }


### PR DESCRIPTION
Replace deprecated NewEnterpriseClient and switch to golangci's lint action.