### PR TITLE
Fix error when no approvers are specified

### DIFF
--- a/approval.go
+++ b/approval.go
@@ -105,9 +105,10 @@ func approvalFromComments(comments []*github.IssueComment, approvers []string, m
 
 	if minimumApprovals == 0 {
 		if len(approvers) == 0 {
-			return "", fmt.Errorf("error: no required approvers or minimum approvals set")
+			minimumApprovals = 1
+		} else {
+			minimumApprovals = len(approvers)
 		}
-		minimumApprovals = len(approvers)
 	}
 
 	for _, comment := range comments {

--- a/approval_test.go
+++ b/approval_test.go
@@ -159,6 +159,34 @@ func TestApprovalFromComments(t *testing.T) {
 			expectedStatus:   approvalStatusPending,
 			minimumApprovals: 2,
 		},
+		{
+			name: "no_approvers_anyone_can_approve",
+			comments: []*github.IssueComment{
+				{
+					User: &github.User{Login: &login1},
+					Body: &bodyApproved,
+				},
+			},
+			approvers:      []string{},
+			expectedStatus: approvalStatusApproved,
+		},
+		{
+			name: "no_approvers_anyone_can_deny",
+			comments: []*github.IssueComment{
+				{
+					User: &github.User{Login: &login1},
+					Body: &bodyDenied,
+				},
+			},
+			approvers:      []string{},
+			expectedStatus: approvalStatusDenied,
+		},
+		{
+			name: "no_approvers_pending_when_no_comments",
+			comments: []*github.IssueComment{},
+			approvers:      []string{},
+			expectedStatus: approvalStatusPending,
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
## Summary
- When `approvers` is empty and `minimumApprovals` is 0 (the "anyone can approve" case), `approvalFromComments` was returning `error: no required approvers or minimum approvals set` instead of allowing any commenter to approve.
- Fix defaults `minimumApprovals` to 1 when both are unset.
- Adds test cases for the no-approvers scenario.