### PR TITLE
chore: upgrade actions/checkout to v6

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Build
         run: make build
         env:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
## Summary
- Upgrade actions/checkout to v6
- v6 uses Node.js 24 runtime (older versions used deprecated Node.js 16/20)
- No breaking changes in input parameters

## Context
GitHub is deprecating Node.js 20 actions runtime. Actions will be forced to Node.js 24 starting June 2nd, 2026.